### PR TITLE
add node and electron to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Proof-of-concept for electron.js. Add a file, select parameters, make a gif.
 
 Git clone and run `npm install` and then `npm start`, probably!
 
-You will need to have ffmpeg installed on your computer already. You also might need to be using macOS.
+You will need to have ffmpeg, node.js and electron.js installed on your computer already. You also might need to be using macOS.
 
 I will figure out how to bundle ffmpeg and make this interoperable, and then everyone can use it!


### PR DESCRIPTION
Hi, I know nothing about node or electron, but on Ubuntu 16.04, I had to install node.js first and then electron in order to get things working.