### PR TITLE
main.js - only allows file selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ const dialog = require('electron').dialog
 
 ipc.on('open-file-dialog', function (event) {
   dialog.showOpenDialog({
-    properties: ['openFile', 'openDirectory']
+    properties: ['openFile']
   }, function (files) {
     if (files) event.sender.send('selected-directory', files)
   })


### PR DESCRIPTION
 This fixes https://github.com/ablwr/git-o-matic/issues/2

It seems that having the `openDirectory` option confused Ubuntu. I'm thinking that it's absence wouldn't mater unless this was transformed into a batch tool?
